### PR TITLE
Run Personal Access Token as intended

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,8 +36,7 @@ jobs:
           git add .
           git commit -m 'Update "${{ github.ref }}"' -a || true
           #git remote set-url origin https://x-access-token:${{ secrets.ACCESS_TOKEN }}@github.com/${{ github.repository }}
-          git remote set-url origin https://sergiu121:${{ secrets.ACCESS_TOKEN }}@github.com/Sergiu121/sergiu121.github.io.git
-          git push
+          git push https://${{ secrets.ACCESS_TOKEN }}@github.com/Sergiu121/sergiu121.github.io.git
           # The above command will fail if no changes were present, so we ignore
           # that.
       - name: Add comment to PR


### PR DESCRIPTION
We were using the token as a password instead of using it as a token in the HTTPS link. This PR fixes this issue and makes it so we can push compiled code to the GitHub page again.